### PR TITLE
Fix for stateful widget issue with AnimatedList

### DIFF
--- a/lib/common_widgets/animated_removal_list/animated_removal_list.dart
+++ b/lib/common_widgets/animated_removal_list/animated_removal_list.dart
@@ -37,20 +37,20 @@ class AnimatedRemovalList<TDataItem> extends StatefulWidget {
 class _AnimatedRemovalListState<TDataItem> extends State<AnimatedRemovalList<TDataItem>> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   //responsible for wrapping the underlying data model and SliverListAnimatedState model, in order to keep them both in sync.
-  late ListModel<TDataItem> _listModel;
+  // late ListModel<TDataItem> _listModel;
 
   //no constructor, as we are not allowed to pass constructor params.  everything must be done in initState
 
   @override
   void initState() {
     super.initState();
-    _listModel = widget.listModel;
+    // _listModel = widget.listModel;
   }
 
   //Called on by SliverAnimatedList's itemBuilder, which is used to build out its widget items when its state is changed by _listModel.listKey.currentState.insertItem
   Widget _buildItem(
       BuildContext context, int index, Animation<double> animation) {
-    final dataItem = _listModel[index];
+    final dataItem = widget.listModel[index];
     return widget.buildItem(context, dataItem, animation, index, ()=> _removeItemAndBuildRemovedItem(context, index, animation, dataItem));
   }
 
@@ -58,9 +58,9 @@ class _AnimatedRemovalListState<TDataItem> extends State<AnimatedRemovalList<TDa
   //item to be removed from the list.
   //note: don't use index as it's typically outdated, as it's from a closure and becomes stale when other items are removed
   _removeItemAndBuildRemovedItem(BuildContext context, int likelyIncorrectIndex, Animation<double> animation, TDataItem dataItem){
-    final indexToRemove = _listModel.indexOf(dataItem);
+    final indexToRemove = widget.listModel.indexOf(dataItem);
     print('_removeItemAndBuildRemovedItem removing $indexToRemove original index: $likelyIncorrectIndex');
-    _listModel.removeAt(indexToRemove, (BuildContext context, TDataItem dataItem, Animation<double> animation, int index) {
+    widget.listModel.removeAt(indexToRemove, (BuildContext context, TDataItem dataItem, Animation<double> animation, int index) {
       return widget.buildRemovedItem(context, dataItem, animation, index);
     });
   }
@@ -73,8 +73,8 @@ class _AnimatedRemovalListState<TDataItem> extends State<AnimatedRemovalList<TDa
           slivers: <Widget>[
             createSliverAppBar(),
             SliverAnimatedList(
-              key: _listModel.listKey,
-              initialItemCount: _listModel.length,
+              key: widget.listModel.listKey,
+              initialItemCount: widget.listModel.length,
               itemBuilder: _buildItem,
             ),
           ],

--- a/lib/common_widgets/animated_removal_list/animated_removal_list_vm.dart
+++ b/lib/common_widgets/animated_removal_list/animated_removal_list_vm.dart
@@ -64,7 +64,8 @@ class ListModel<TDataItem> {
               (BuildContext context, Animation<double> animation){
             print('animatedList removeItem builder called index: $index');
             return buildRemovedItem(context, removedDataItem, animation, index);
-          }
+          },
+        duration: Duration(seconds: 3)
       );
     }
     return removedDataItem;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_playground/widgets/SliverAnimatedListFromFlutterDev.dart';
 import 'package:flutter_playground/widgets/discovered_accounts/discovered_accounts.dart';
 
 void main() {
@@ -104,6 +105,7 @@ class _MyHomePageState extends State<MyHomePage> {
               width: 500,
               height: 500,
               child: DiscoveredAccounts(),
+              // child: SliverAnimatedListSample(),
             ),
             // const SliverAnimatedListSample(),
             Text(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_playground/widgets/discovered_accounts/discovered_accounts.dart';
-import 'common_widgets/animated_removal_list/animated_removal_list.dart';
 
 void main() {
   runApp(const MyApp());
@@ -64,6 +63,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
+    print('Main build called');
     Size size = MediaQuery.of(context).size;
     // This method is rerun every time setState is called, for instance as done
     // by the _incrementCounter method above.

--- a/lib/view_models/discovered_accounts_list_data_item.dart
+++ b/lib/view_models/discovered_accounts_list_data_item.dart
@@ -1,6 +1,8 @@
 class DiscoveredAccountsListDataItem {
   final String displayText;
+  bool isLoading;
   DiscoveredAccountsListDataItem({
     required this.displayText,
+    this.isLoading = false,
   });
 }

--- a/lib/widgets/SliverAnimatedListFromFlutterDev.dart
+++ b/lib/widgets/SliverAnimatedListFromFlutterDev.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+
+class SliverAnimatedListSample extends StatefulWidget {
+  const SliverAnimatedListSample({super.key});
+
+  @override
+  State<SliverAnimatedListSample> createState() =>
+      _SliverAnimatedListSampleState();
+}
+
+class _SliverAnimatedListSampleState extends State<SliverAnimatedListSample> {
+  final GlobalKey<SliverAnimatedListState> _listKey =
+  GlobalKey<SliverAnimatedListState>();
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+  final GlobalKey<ScaffoldMessengerState> _scaffoldMessengerKey =
+  GlobalKey<ScaffoldMessengerState>();
+  late ListModel<int> _list;
+  int? _selectedItem;
+  late int
+  _nextItem; // The next item inserted when the user presses the '+' button.
+
+  @override
+  void initState() {
+    super.initState();
+    _list = ListModel<int>(
+      listKey: _listKey,
+      initialItems: <int>[0, 1, 2],
+      removedItemBuilder: _buildRemovedItem,
+    );
+    _nextItem = 3;
+  }
+
+  // Used to build list items that haven't been removed.
+  Widget _buildItem(
+      BuildContext context, int index, Animation<double> animation) {
+    return CardItem(
+      animation: animation,
+      item: _list[index],
+      selected: _selectedItem == _list[index],
+      onTap: () {
+        setState(() {
+          _selectedItem = _selectedItem == _list[index] ? null : _list[index];
+        });
+      },
+    );
+  }
+
+  /// The builder function used to build items that have been removed.
+  ///
+  /// Used to build an item after it has been removed from the list. This method
+  /// is needed because a removed item remains visible until its animation has
+  /// completed (even though it's gone as far this ListModel is concerned). The
+  /// widget will be used by the [AnimatedListState.removeItem] method's
+  /// [AnimatedRemovedItemBuilder] parameter.
+  Widget _buildRemovedItem(
+      int item, BuildContext context, Animation<double> animation) {
+    return CardItem(
+      animation: animation,
+      item: item,
+    );
+  }
+
+  // Insert the "next item" into the list model.
+  void _insert() {
+    final int index =
+    _selectedItem == null ? _list.length : _list.indexOf(_selectedItem!);
+    _list.insert(index, _nextItem++);
+  }
+
+  // Remove the selected item from the list model.
+  void _remove() {
+    if (_selectedItem != null) {
+      _list.removeAt(_list.indexOf(_selectedItem!));
+      setState(() {
+        _selectedItem = null;
+      });
+    } else {
+      _scaffoldMessengerKey.currentState!.showSnackBar(const SnackBar(
+        content: Text(
+          'Select an item to remove from the list.',
+          style: TextStyle(fontSize: 20),
+        ),
+      ));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      scaffoldMessengerKey: _scaffoldMessengerKey,
+      home: Scaffold(
+        key: _scaffoldKey,
+        body: CustomScrollView(
+          slivers: <Widget>[
+            SliverAppBar(
+              title: const Text(
+                'SliverAnimatedList',
+                style: TextStyle(fontSize: 30),
+              ),
+              expandedHeight: 60,
+              centerTitle: true,
+              backgroundColor: Colors.amber[900],
+              leading: IconButton(
+                icon: const Icon(Icons.add_circle),
+                onPressed: _insert,
+                tooltip: 'Insert a new item.',
+                iconSize: 32,
+              ),
+              actions: <Widget>[
+                IconButton(
+                  icon: const Icon(Icons.remove_circle),
+                  onPressed: _remove,
+                  tooltip: 'Remove the selected item.',
+                  iconSize: 32,
+                ),
+              ],
+            ),
+            SliverAnimatedList(
+              key: _listKey,
+              initialItemCount: _list.length,
+              itemBuilder: _buildItem,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+typedef RemovedItemBuilder = Widget Function(
+    int item, BuildContext context, Animation<double> animation);
+
+// Keeps a Dart [List] in sync with an [AnimatedList].
+//
+// The [insert] and [removeAt] methods apply to both the internal list and
+// the animated list that belongs to [listKey].
+//
+// This class only exposes as much of the Dart List API as is needed by the
+// sample app. More list methods are easily added, however methods that
+// mutate the list must make the same changes to the animated list in terms
+// of [AnimatedListState.insertItem] and [AnimatedList.removeItem].
+class ListModel<E> {
+  ListModel({
+    required this.listKey,
+    required this.removedItemBuilder,
+    Iterable<E>? initialItems,
+  }) : _items = List<E>.from(initialItems ?? <E>[]);
+
+  final GlobalKey<SliverAnimatedListState> listKey;
+  final RemovedItemBuilder removedItemBuilder;
+  final List<E> _items;
+
+  SliverAnimatedListState get _animatedList => listKey.currentState!;
+
+  void insert(int index, E item) {
+    _items.insert(index, item);
+    _animatedList.insertItem(index);
+  }
+
+  E removeAt(int index) {
+    final E removedItem = _items.removeAt(index);
+    if (removedItem != null) {
+      _animatedList.removeItem(
+        index,
+            (BuildContext context, Animation<double> animation) =>
+            removedItemBuilder(index, context, animation),
+      );
+    }
+    return removedItem;
+  }
+
+  int get length => _items.length;
+
+  E operator [](int index) => _items[index];
+
+  int indexOf(E item) => _items.indexOf(item);
+}
+
+// Displays its integer item as 'Item N' on a Card whose color is based on
+// the item's value.
+//
+// The card turns gray when [selected] is true. This widget's height
+// is based on the [animation] parameter. It varies as the animation value
+// transitions from 0.0 to 1.0.
+class CardItem extends StatelessWidget {
+  const CardItem({
+    super.key,
+    this.onTap,
+    this.selected = false,
+    required this.animation,
+    required this.item,
+  }) : assert(item >= 0);
+
+  final Animation<double> animation;
+  final VoidCallback? onTap;
+  final int item;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(
+        left: 2.0,
+        right: 2.0,
+        top: 2.0,
+      ),
+      child: SizeTransition(
+        sizeFactor: animation,
+        child: GestureDetector(
+          onTap: onTap,
+          child: SizedBox(
+            height: 80.0,
+            child: Card(
+              color: selected
+                  ? Colors.black12
+                  : Colors.primaries[item % Colors.primaries.length],
+              child: Center(
+                child: Text(
+                  'Item $item',
+                  style: Theme.of(context).textTheme.headlineMedium,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/SliverAnimatedListFromFlutterDev.dart
+++ b/lib/widgets/SliverAnimatedListFromFlutterDev.dart
@@ -163,7 +163,7 @@ class ListModel<E> {
       _animatedList.removeItem(
         index,
             (BuildContext context, Animation<double> animation) =>
-            removedItemBuilder(index, context, animation),
+            removedItemBuilder(removedItem as int, context, animation),
       );
     }
     return removedItem;

--- a/lib/widgets/discovered_accounts/discovered_accounts.dart
+++ b/lib/widgets/discovered_accounts/discovered_accounts.dart
@@ -5,45 +5,50 @@ import 'package:provider/provider.dart';
 import '../../view_models/discovered_accounts_list_data_item.dart';
 import 'discovered_accounts_vm.dart';
 
-class DiscoveredAccounts extends StatelessWidget{
+class DiscoveredAccounts extends StatefulWidget{
   const DiscoveredAccounts({Key? key}) : super(key: key);
+  @override
+  State<StatefulWidget> createState() => DiscoveredAccountsState();
+}
 
+class DiscoveredAccountsState extends State<DiscoveredAccounts>{
+  late final DiscoveredAccountsVM discoveredAccountsVM;
+  @override
+  initState(){
+    print('DiscoveredAccountsState initState');
+    discoveredAccountsVM = DiscoveredAccountsVM();
+    discoveredAccountsVM.getDiscoveredAccounts(); //the list will re-render after this call completes
+  }
   @override
   Widget build(BuildContext context) {
-    // return const AnimatedRemovalList();
+    print('DiscoveredAccountsState build called');
     return Scaffold(
-      body: ChangeNotifierProvider(
-        create: (_){
-          return DiscoveredAccountsVM()..getDiscoveredAccounts();
-        },
-        child: Consumer<DiscoveredAccountsVM>(
-          builder: (context, discoveredAccountsVM, _){
-            return AnimatedRemovalList<DiscoveredAccountsListDataItem>(
-                listModel: discoveredAccountsVM.listModel,
-                buildItem: (BuildContext context, DiscoveredAccountsListDataItem dataItem, Animation<double> animation, int index, VoidCallback removeItemFromList){
-                  return buildItem(index, dataItem, discoveredAccountsVM, removeItemFromList);
-                },
-                buildRemovedItem: (BuildContext context, DiscoveredAccountsListDataItem dataItem, Animation<double> animation, int index){
-                  return buildRemovedItem(context, dataItem, animation, index);
-                },
-            );
+        body:  AnimatedRemovalList<DiscoveredAccountsListDataItem>(
+          listModel: discoveredAccountsVM.listModel,
+          buildItem: (BuildContext context, DiscoveredAccountsListDataItem dataItem, Animation<double> animation, int index, VoidCallback removeItemFromList){
+            return buildItem(index, dataItem, discoveredAccountsVM, removeItemFromList);
+          },
+          buildRemovedItem: (BuildContext context, DiscoveredAccountsListDataItem dataItem, Animation<double> animation, int index){
+            return buildRemovedItem(context, dataItem, animation, index);
           },
         )
-      )
     );
   }
 
-  //called on for each item from getDiscoveredAccounts
+  //called on for each item from getDiscoveredAccounts call to listModel.insertAll(dataItems)
   Widget buildItem(int index,  DiscoveredAccountsListDataItem dataItem, DiscoveredAccountsVM discoveredAccountsVM, VoidCallback removeItemFromList){
     DiscoveredAccountsListDataItem dataItem = discoveredAccountsVM.listModel[index];
-    return DiscoveredAccountsListItem(dataItem: dataItem, onLinkAccountToBUPressed: (){
-      onLinkAccountToBUPressed(dataItem, removeItemFromList);
+    print('buildItem called for ${dataItem.displayText} index: $index');
+    return DiscoveredAccountsListItem(dataItem: dataItem, onLinkAccountToBUPressed: (discoveredAccountsListItemState){
+      onLinkAccountToBUPressed(dataItem, removeItemFromList, discoveredAccountsListItemState);
     });
   }
 
-  onLinkAccountToBUPressed(DiscoveredAccountsListDataItem dataItem, VoidCallback removeItemFromList) async{
+  onLinkAccountToBUPressed(DiscoveredAccountsListDataItem dataItem, VoidCallback removeItemFromList, DiscoveredAccountsListItemState discoveredAccountsListItemState) async{
     try {
-      await DiscoveredAccountsVM().linkAccountToBu(dataItem);
+      discoveredAccountsListItemState.setIsLoading(true);
+      // await DiscoveredAccountsVM().linkAccountToBu(dataItem);
+      // discoveredAccountsListItemState.setIsLoading(false);
       removeItemFromList();
     }catch(e){
       print('error linkAccountToBU $e');
@@ -51,7 +56,7 @@ class DiscoveredAccounts extends StatelessWidget{
   }
 
   Widget buildRemovedItem(BuildContext context, DiscoveredAccountsListDataItem dataItem, Animation<double> animation, int index){
-    DiscoveredAccountsListDataItem d = DiscoveredAccountsListDataItem(displayText: 'removed...');
-    return DiscoveredAccountsListItem(dataItem: d, onLinkAccountToBUPressed: ()=>{},);
+    DiscoveredAccountsListDataItem d = DiscoveredAccountsListDataItem(displayText: 'removed');
+    return DiscoveredAccountsListItem(dataItem: d, onLinkAccountToBUPressed: (_)=>{},);
   }
 }

--- a/lib/widgets/discovered_accounts/discovered_accounts.dart
+++ b/lib/widgets/discovered_accounts/discovered_accounts.dart
@@ -47,7 +47,7 @@ class DiscoveredAccountsState extends State<DiscoveredAccounts>{
   onLinkAccountToBUPressed(DiscoveredAccountsListDataItem dataItem, VoidCallback removeItemFromList, DiscoveredAccountsListItemState discoveredAccountsListItemState) async{
     try {
       discoveredAccountsListItemState.setIsLoading(true);
-      // await DiscoveredAccountsVM().linkAccountToBu(dataItem);
+      await DiscoveredAccountsVM().linkAccountToBu(dataItem);
       // discoveredAccountsListItemState.setIsLoading(false);
       removeItemFromList();
     }catch(e){

--- a/lib/widgets/discovered_accounts/discovered_accounts_list_item.dart
+++ b/lib/widgets/discovered_accounts/discovered_accounts_list_item.dart
@@ -1,25 +1,50 @@
 import 'package:flutter/material.dart';
 import '../../view_models/discovered_accounts_list_data_item.dart';
 
-class DiscoveredAccountsListItem extends StatelessWidget{
+//issue with stateful widgets in sliveranimatedlist
+//https://github.com/flutter/flutter/issues/101551
+
+class DiscoveredAccountsListItem extends StatefulWidget{
   final DiscoveredAccountsListDataItem dataItem;
-  final VoidCallback onLinkAccountToBUPressed;
+  final Function(DiscoveredAccountsListItemState listItemStatePressed) onLinkAccountToBUPressed;
 
   const DiscoveredAccountsListItem({Key? key, required this.dataItem, required this.onLinkAccountToBUPressed}) : super(key: key);
+  @override
+  State<StatefulWidget> createState() => DiscoveredAccountsListItemState();
+}
+
+class DiscoveredAccountsListItemState extends State<DiscoveredAccountsListItem>{
+  late bool _isLoading = false;
+
+  @override
+  initState(){
+    super.initState();
+    // print('initState for ${widget.dataItem.displayText}');
+    _isLoading = false;
+  }
+  setIsLoading(bool isLoading){
+    setState((){
+      print('setIsLoading called: $isLoading for ${widget.dataItem.displayText}');
+      _isLoading = isLoading;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
-
+    final displayText = _isLoading ? '...${widget.dataItem.displayText}' : widget.dataItem.displayText;
+    print('build called for ${widget.dataItem.displayText} isLoading: $_isLoading');
     return Row(
       children: [
         Expanded(child:Text(
-            '${dataItem.displayText}',
+            displayText,
             style: Theme.of(context).textTheme.headlineMedium,
           ),
         ),
         Expanded(child: IconButton(
           icon: const Icon(Icons.remove_circle),
-          onPressed: onLinkAccountToBUPressed,
+          onPressed: () {
+            widget.onLinkAccountToBUPressed(this);
+          },
           tooltip: 'Remove the selected item.',
           iconSize: 32,
         ),)

--- a/lib/widgets/discovered_accounts/discovered_accounts_list_item.dart
+++ b/lib/widgets/discovered_accounts/discovered_accounts_list_item.dart
@@ -9,30 +9,47 @@ class DiscoveredAccountsListItem extends StatefulWidget{
   final Function(DiscoveredAccountsListItemState listItemStatePressed) onLinkAccountToBUPressed;
 
   const DiscoveredAccountsListItem({Key? key, required this.dataItem, required this.onLinkAccountToBUPressed}) : super(key: key);
+  // @override
+  // State<StatefulWidget> createState() => DiscoveredAccountsListItemState();
   @override
-  State<StatefulWidget> createState() => DiscoveredAccountsListItemState();
+  State<StatefulWidget> createState(){
+    print('create state called for ${dataItem.displayText}');
+    return DiscoveredAccountsListItemState();
+  }
+
 }
 
 class DiscoveredAccountsListItemState extends State<DiscoveredAccountsListItem>{
-  late bool _isLoading = false;
-
+  late DiscoveredAccountsListDataItem _dataItem;
   @override
   initState(){
     super.initState();
-    // print('initState for ${widget.dataItem.displayText}');
-    _isLoading = false;
+    _dataItem = widget.dataItem;
   }
   setIsLoading(bool isLoading){
+    _dataItem.isLoading = isLoading;
     setState((){
       print('setIsLoading called: $isLoading for ${widget.dataItem.displayText}');
-      _isLoading = isLoading;
+      _dataItem = _dataItem;
     });
+  }
+
+  _setDataItemIfNeeded(){
+    if(_dataItem != widget.dataItem){
+      print('data items dont match so updating state');
+        setState((){
+          _dataItem = widget.dataItem;
+        });
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    final displayText = _isLoading ? '...${widget.dataItem.displayText}' : widget.dataItem.displayText;
-    print('build called for ${widget.dataItem.displayText} isLoading: $_isLoading');
+    final displayText = _dataItem.isLoading ? '...backend call' : widget.dataItem.displayText;
+    print('build called for ${widget.dataItem.displayText} isLoading: ${_dataItem.isLoading} state. state _dataItem.displayText: ${_dataItem.displayText}');
+    //hack
+    _setDataItemIfNeeded();
+
     return Row(
       children: [
         Expanded(child:Text(

--- a/lib/widgets/discovered_accounts/discovered_accounts_list_item.dart
+++ b/lib/widgets/discovered_accounts/discovered_accounts_list_item.dart
@@ -43,6 +43,7 @@ class DiscoveredAccountsListItemState extends State<DiscoveredAccountsListItem>{
         Expanded(child: IconButton(
           icon: const Icon(Icons.remove_circle),
           onPressed: () {
+            setIsLoading(true);
             widget.onLinkAccountToBUPressed(this);
           },
           tooltip: 'Remove the selected item.',

--- a/lib/widgets/discovered_accounts/discovered_accounts_vm.dart
+++ b/lib/widgets/discovered_accounts/discovered_accounts_vm.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import '../../common_widgets/animated_removal_list/animated_removal_list_vm.dart';
 import '../../view_models/discovered_accounts_list_data_item.dart';
 
-class DiscoveredAccountsVM extends ChangeNotifier{
+class DiscoveredAccountsVM{
   late final ListModel<DiscoveredAccountsListDataItem> listModel;
   DiscoveredAccountsVM(){
     listModel = ListModel(
@@ -17,7 +17,7 @@ class DiscoveredAccountsVM extends ChangeNotifier{
     final dataItems = await fakeBackendCallToGetDiscoveredAccounts();
     //update the dataItems corresponding sliverAnimatedListState
     listModel.insertAll(dataItems);
-    notifyListeners();
+    // notifyListeners();
   }
 
   Future<void> linkAccountToBu(DiscoveredAccountsListDataItem dataItem) async {
@@ -26,6 +26,7 @@ class DiscoveredAccountsVM extends ChangeNotifier{
 }
 
 Future<List<DiscoveredAccountsListDataItem>> fakeBackendCallToGetDiscoveredAccounts() async {
+  await Future.delayed(const Duration(seconds: 1));
   return <DiscoveredAccountsListDataItem>[
     DiscoveredAccountsListDataItem(displayText: 'Account 0'),
     DiscoveredAccountsListDataItem(displayText: 'Account 1'),

--- a/lib/widgets/discovered_accounts/discovered_accounts_with_change_notifier.dart
+++ b/lib/widgets/discovered_accounts/discovered_accounts_with_change_notifier.dart
@@ -1,0 +1,60 @@
+// import 'package:flutter/material.dart';
+// import 'package:flutter_playground/common_widgets/animated_removal_list/animated_removal_list.dart';
+// import 'package:flutter_playground/widgets/discovered_accounts/discovered_accounts_list_item.dart';
+// import 'package:provider/provider.dart';
+// import '../../view_models/discovered_accounts_list_data_item.dart';
+// import 'discovered_accounts_vm.dart';
+//
+// class DiscoveredAccounts extends StatelessWidget{
+//   const DiscoveredAccounts({Key? key}) : super(key: key);
+//
+//   @override
+//   Widget build(BuildContext context) {
+//     // return const AnimatedRemovalList();
+//     return Scaffold(
+//       body: ChangeNotifierProvider(//wait for vm getDiscoveredAccounts to return before rendering
+//         create: (_){
+//           return DiscoveredAccountsVM()..getDiscoveredAccounts();
+//         },
+//         child: Consumer<DiscoveredAccountsVM>(
+//           builder: (context, discoveredAccountsVM, _){
+//             print('building AnimatedRemovalList');
+//             return AnimatedRemovalList<DiscoveredAccountsListDataItem>(
+//                 listModel: discoveredAccountsVM.listModel,
+//                 buildItem: (BuildContext context, DiscoveredAccountsListDataItem dataItem, Animation<double> animation, int index, VoidCallback removeItemFromList){
+//                   return buildItem(index, dataItem, discoveredAccountsVM, removeItemFromList);
+//                 },
+//                 buildRemovedItem: (BuildContext context, DiscoveredAccountsListDataItem dataItem, Animation<double> animation, int index){
+//                   return buildRemovedItem(context, dataItem, animation, index);
+//                 },
+//             );
+//           },
+//         )
+//       )
+//     );
+//   }
+//
+//   //called on for each item from getDiscoveredAccounts call to listModel.insertAll(dataItems)
+//   Widget buildItem(int index,  DiscoveredAccountsListDataItem dataItem, DiscoveredAccountsVM discoveredAccountsVM, VoidCallback removeItemFromList){
+//     print('buildItem called for index: $index');
+//     DiscoveredAccountsListDataItem dataItem = discoveredAccountsVM.listModel[index];
+//     return DiscoveredAccountsListItem(dataItem: dataItem, onLinkAccountToBUPressed: (discoveredAccountsListItemState){
+//       onLinkAccountToBUPressed(dataItem, removeItemFromList, discoveredAccountsListItemState);
+//     });
+//   }
+//
+//   onLinkAccountToBUPressed(DiscoveredAccountsListDataItem dataItem, VoidCallback removeItemFromList, DiscoveredAccountsListItemState discoveredAccountsListItemState) async{
+//     try {
+//       discoveredAccountsListItemState.setIsLoading(true);
+//       await DiscoveredAccountsVM().linkAccountToBu(dataItem);
+//       removeItemFromList();
+//     }catch(e){
+//       print('error linkAccountToBU $e');
+//     }
+//   }
+//
+//   Widget buildRemovedItem(BuildContext context, DiscoveredAccountsListDataItem dataItem, Animation<double> animation, int index){
+//     DiscoveredAccountsListDataItem d = DiscoveredAccountsListDataItem(displayText: 'removed...');
+//     return DiscoveredAccountsListItem(dataItem: d, onLinkAccountToBUPressed: (_)=>{},);
+//   }
+// }


### PR DESCRIPTION
This has a hack to get around the animatedlist assigning incorrect state to list item widgets when an item is removed from the list.

The trick is to hold state in DataItem, then have ListItemState have a reference to DataItem.

During build, if the widget.dataItem does not match state _dataItem, call set state and set _dataItem to widget.dataItem.